### PR TITLE
configurable ldap timeout (fixes #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ List of configurable values:
 |`config.ldap.bindpw`|Password of LDAP bind user|`LDAP_BINDPW`|secret|
 |`config.ldap.baseDn`|Base DN for LDAP search|`LDAP_BASEDN`|dc=example,dc=com|
 |`config.ldap.filter`|Filter for LDAP search|`LDAP_FILTER`|(uid=%s)|
+|`config.ldap.timeout`|Timeout for LDAP connections & operations|`LDAP_TIMEOUT`|0 (infinite for operations, OS default for connections)|
 |`config.jwt.key`|Key for signing the JWT. **DO NOT USE THE DEFAULT VALUE IN PRODUCTION**|`JWT_KEY`|secret|
 |`config.jwt.tokenLifetime`|Seconds until token a expires|`JWT_TOKEN_LIFETIME`|28800|
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ List of configurable values:
 |`config.ldap.bindpw`|Password of LDAP bind user|`LDAP_BINDPW`|secret|
 |`config.ldap.baseDn`|Base DN for LDAP search|`LDAP_BASEDN`|dc=example,dc=com|
 |`config.ldap.filter`|Filter for LDAP search|`LDAP_FILTER`|(uid=%s)|
-|`config.ldap.timeout`|Timeout for LDAP connections & operations|`LDAP_TIMEOUT`|0 (infinite for operations, OS default for connections)|
+|`config.ldap.timeout`|Timeout for LDAP connections & operations (in seconds)|`LDAP_TIMEOUT`|0 (infinite for operations, OS default for connections)|
 |`config.jwt.key`|Key for signing the JWT. **DO NOT USE THE DEFAULT VALUE IN PRODUCTION**|`JWT_KEY`|secret|
 |`config.jwt.tokenLifetime`|Seconds until token a expires|`JWT_TOKEN_LIFETIME`|28800|
 

--- a/src/config.js
+++ b/src/config.js
@@ -19,6 +19,7 @@ const getConfig = () => {
       bindPw: process.env.LDAP_BINDPW || 'secret',
       baseDn: process.env.LDAP_BASEDN || 'dc=example,dc=com',
       filter: process.env.LDAP_FILTER || '(uid=%s)',
+      timeout: parseInt(process.env.LDAP_TIMEOUT) || 0,
     },
     jwt: {
       key: process.env.JWT_KEY || 'secret',

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,8 @@ const logger = new Logger({
 let ldapClient = new Client(
   ldap.createClient({
     url: config.ldap.uri,
+    timeout: config.ldap.timeout,
+    connectTimeout: config.ldap.timeout,
   }),
   config.ldap.baseDn,
   config.ldap.bindDn,

--- a/src/index.js
+++ b/src/index.js
@@ -28,8 +28,8 @@ const logger = new Logger({
 let ldapClient = new Client(
   ldap.createClient({
     url: config.ldap.uri,
-    timeout: config.ldap.timeout,
-    connectTimeout: config.ldap.timeout,
+    timeout: config.ldap.timeout * 1000,
+    connectTimeout: config.ldap.timeout * 1000,
   }),
   config.ldap.baseDn,
   config.ldap.bindDn,

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -48,7 +48,7 @@ const fixtures = {
     default: true,
     testValues: [
       {value: 'false', expected: false},
-      {value: 'abc', expected: true}
+      {value: 'abc', expected: true},
     ],
   },
   'tls.cert': {
@@ -78,11 +78,8 @@ const fixtures = {
 for (let setting of Object.keys(fixtures)) {
   describe('config.' + setting, () => {
     test('test default value [' + fixtures[setting].default + ']', () => {
-      // console.log(setting)
-      // console.log(config)
-      // console.log(config[setting])
       delete process.env[fixtures[setting].env];
-      let config = getConfig();
+      let config = getConfig(); // eslint-disable-line no-unused-vars
       expect(eval('config.' + setting)).toBe(fixtures[setting].default);
     });
     for (let testValue of fixtures[setting].testValues) {
@@ -94,7 +91,7 @@ for (let setting of Object.keys(fixtures)) {
       }
       test('test custom value [' + value + ']', () => {
         process.env[fixtures[setting].env] = value;
-        let config = getConfig();
+        let config = getConfig(); // eslint-disable-line no-unused-vars
         expect(eval('config.' + setting)).toBe(expected);
       });
     };

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -31,6 +31,13 @@ const fixtures = {
     default: '(uid=%s)',
     testValues: ['(mail=%s)'],
   },
+  'ldap.timeout': {
+    env: 'LDAP_TIMEOUT',
+    default: 0,
+    testValues: [
+      {value: '30', expected: 30},
+    ],
+  },
   'jwt.key': {
     env: 'JWT_KEY',
     default: 'secret',


### PR DESCRIPTION
new config parameter: `config.ldap.timeout` (configurable via `LDAP_TIMEOUT`): ldap connection and operation timeout in seconds (passed to ldapjs client options `connectionTimeout` and `timeout`)