### PR TITLE
Handle response from AD with groups as single string

### DIFF
--- a/src/ldap/mapping.js
+++ b/src/ldap/mapping.js
@@ -45,7 +45,7 @@ class Mapping {
     let object = {
       username: ldapObject[this.username],
       uid: ldapObject[this.uid],
-      groups: ldapObject[this.groups].map((group) => {
+      groups: this.getGroups(ldapObject).map((group) => {
         return canonicalizeDn(group);
       }),
       extra: {},
@@ -54,6 +54,20 @@ class Mapping {
       object.extra[extraField] = ldapObject[extraField];
     }
     return object;
+  }
+
+  /**
+  * Get group of LDAP object
+  * @param {Object} ldapObject - Ldap object to convert
+  * @return {Array}
+  */
+  getGroups(ldapObject: Object): Array<string> {
+    let groups = ldapObject[this.groups];
+    if (groups instanceof Array) {
+      return groups;
+    } else {
+      return [groups];
+    }
   }
 }
 

--- a/test/unit/ldap/mapping.test.js
+++ b/test/unit/ldap/mapping.test.js
@@ -23,12 +23,30 @@ const fixtures = {
     uidNumber: 1,
     gidNumber: [10, 11],
   },
+  ldapObjectWithSingleGroup: {
+    mail: 'john.doe@example.com',
+    cn: 'john.doe',
+    memberOf: 'cn=kubernetes,ou=groups,dc=example,dc=com',
+    uidNumber: 1,
+    gidNumber: [10, 11],
+  },
   kubernetesObject: {
     username: 'john.doe@example.com',
     uid: 'john.doe',
     groups: [
       'kubernetes',
       'user',
+    ],
+    extra: {
+      'uidNumber': 1,
+      'gidNumber': [10, 11],
+    },
+  },
+  kubernetesObjectWithSingleGroup: {
+    username: 'john.doe@example.com',
+    uid: 'john.doe',
+    groups: [
+      'kubernetes',
     ],
     extra: {
       'uidNumber': 1,
@@ -75,5 +93,18 @@ describe('Mapping.ldapToKubernetes()', () => {
     expect(
       mapping.ldapToKubernetes(fixtures.ldapObject)
     ).toEqual(fixtures.kubernetesObject);
+  });
+
+  test('handles when groups attribute is a single object', () => {
+    let mapping = new Mapping(
+      fixtures.mapping.username,
+      fixtures.mapping.uid,
+      fixtures.mapping.groups,
+      fixtures.mapping.extraFields
+    );
+
+    expect(
+      mapping.ldapToKubernetes(fixtures.ldapObjectWithSingleGroup)
+    ).toEqual(fixtures.kubernetesObjectWithSingleGroup);
   });
 });


### PR DESCRIPTION
In our environment with Active Directory on Windows Server 2016 we don't
get a response where `memberOf` is a list but instead a string with a
single group. Adjust the code to allow for such responses.