### PR TITLE
Bump base image for container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.10.0-alpine
+FROM node:8.15.0-alpine
 
 RUN apk --no-cache add ca-certificates wget && \
   wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \


### PR DESCRIPTION
The base image for the container is bumped from Node 8.10 to 8.15 which
also bumps Alpine from 3.6 to 3.8.