### PR TITLE
don't allow login with empty password

### DIFF
--- a/src/ldap/authenticator.js
+++ b/src/ldap/authenticator.js
@@ -28,6 +28,10 @@ export default class Authenticator {
   * @return {Promise<boolean>}
   */
   async authenticate(username: string, password: string): Promise<boolean> {
+    if (password === '') {
+      this.logger.info('empty password');
+      return false;
+    }
     let filter = util.format(this.filter, username);
     try {
       let user = await this.client.search(filter);


### PR DESCRIPTION
We noticed that one can successfully authenticate with a valid username and an empty password, if anonymous binds are enabled on the LDAP server.
This PR prevents that.
